### PR TITLE
added data-stubbing to UnifiedAlchemyMagicMock

### DIFF
--- a/.importanizerc
+++ b/.importanizerc
@@ -2,12 +2,12 @@
     "add_imports": [
         "from __future__ import absolute_import, print_function, unicode_literals"
     ],
+    "exclude": [
+        "*/.tox/*"
+    ],
     "groups": [
         {
             "type": "stdlib"
-        },
-        {
-            "type": "sitepackages"
         },
         {
             "type": "remainder"

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,12 @@
 History
 -------
 
+0.2.0 (2018-01-13)
+~~~~~~~~~~~~~~~~~~
+
+* Added ability to stub real-data by filtering criteria.
+  See `#2 <https://github.com/miki725/alchemy-mock/pull/2>`_.
+
 0.1.1 (2018-01-12)
 ~~~~~~~~~~~~~~~~~~
 

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ clean-all:  ## remove tox test artifacts
 
 lint:  ## check style with flake8 and importanize
 	flake8 alchemy_mock
-	python -m importanize alchemy_mock/
+	python -m importanize --ci alchemy_mock/
 
 test: clean  ## run all tests
 	pytest --doctest-modules --cov=alchemy_mock/ --cov-report=term-missing alchemy_mock/

--- a/README.rst
+++ b/README.rst
@@ -64,15 +64,16 @@ In those cases ``UnifiedAlchemyMagicMock`` can be used which combines various ca
     >>> from alchemy_mock.mocking import UnifiedAlchemyMagicMock
     >>> session = UnifiedAlchemyMagicMock()
 
-    >>> q = session.query(Model).filter(Model.foo == 5)
+    >>> m = session.query(Model)
+    >>> q = m.filter(Model.foo == 5)
     >>> if condition:
-    ...     q = q.filter(Model.bar > 10)
+    ...     q = q.filter(Model.bar > 10).all()
     >>> data1 = q.all()
-    >>> data2 = q.filter(Model.note == 'hello world').all()
+    >>> data2 = m.filter(Model.note == 'hello world').all()
 
     >>> session.filter.assert_has_calls([
     ...     mock.call(Model.foo == 5, Model.bar > 10),
-    ...     mock.call(Model.foo == 5, Model.bar > 10, Model.note == 'hello world'),
+    ...     mock.call(Model.note == 'hello world'),
     ... ])
 
 Also real-data can be stubbed by criteria::

--- a/README.rst
+++ b/README.rst
@@ -74,3 +74,32 @@ In those cases ``UnifiedAlchemyMagicMock`` can be used which combines various ca
     ...     mock.call(Model.foo == 5, Model.bar > 10),
     ...     mock.call(Model.foo == 5, Model.bar > 10, Model.note == 'hello world'),
     ... ])
+
+Also real-data can be stubbed by criteria::
+
+    >>> from alchemy_mock.mocking import UnifiedAlchemyMagicMock
+    >>> session = UnifiedAlchemyMagicMock(data=[
+    ...     (
+    ...         [mock.call.query(Model),
+    ...          mock.call.filter(Model.foo == 5, Model.bar > 10)],
+    ...         [Model(foo=5, bar=11)]
+    ...     ),
+    ...     (
+    ...         [mock.call.query(Model),
+    ...          mock.call.filter(Model.note == 'hello world')],
+    ...         [Model(note='hello world')]
+    ...     ),
+    ...     (
+    ...         [mock.call.query(AnotherModel),
+    ...          mock.call.filter(Model.foo == 5, Model.bar > 10)],
+    ...         [AnotherModel(foo=5, bar=17)]
+    ...     ),
+    ... ])
+    >>> session.query(Model).filter(Model.foo == 5).filter(Model.bar > 10).all()
+    [Model(foo=5, bar=11)]
+    >>> session.query(Model).filter(Model.note == 'hello world').all()
+    [Model(note='hello world')]
+    >>> session.query(AnotherModel).filter(Model.foo == 5).filter(Model.bar > 10).all()
+    [AnotherModel(foo=5, bar=17)]
+    >>> session.query(AnotherModel).filter(Model.note == 'hello world').all()
+    []

--- a/alchemy_mock/__init__.py
+++ b/alchemy_mock/__init__.py
@@ -2,6 +2,6 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 
-__version__ = '0.1.1'
+__version__ = '0.2.0'
 __description__ = 'SQLAlchemy mock helpers.'
 __author__ = 'Miroslav Shubernetskiy'

--- a/alchemy_mock/mocking.py
+++ b/alchemy_mock/mocking.py
@@ -147,6 +147,8 @@ class UnifiedAlchemyMagicMock(AlchemyMagicMock):
         [3]
         >>> s.query(None).filter(c == 'four').all()
         []
+        >>> list(s.query('foo').filter(c == 'one').filter(c == 'two'))
+        [1, 2]
 
     Also note that only within same query functions are unified.
     After ``.all()`` is called or query is iterated over, future queries are not unified.
@@ -244,7 +246,7 @@ class UnifiedAlchemyMagicMock(AlchemyMagicMock):
         if _mock_data is not None:
             previous_calls = [
                 sqlalchemy_call(i, with_name=True)
-                for i in self._get_previous_calls(self.method_calls[:-1])
+                for i in self._get_previous_calls(self.mock_calls[:-1])
             ]
 
             for calls, result in sorted(_mock_data, key=lambda x: len(x[0]), reverse=True):


### PR DESCRIPTION
eventually settled on this API. seems the cleanest of all options I thought of.

some criteria which it needed to satisfy:

* has to be potentially aware of all criteria used within a single transaction (all method calls between `.all()` or `.__iter__()` in session which actually result some result)
* has to be graceful with criteria so things like `.order_by()`, `.join()` do not have to specified in order to match results
* order of method calls should not matter. `.order_by()` can be called first, etc

some options which I had:

### option 1 - inline definitions next to mock methods with utility method

```python
mock_session.query.with(Model).filter.with(Model.foo == 'bar').results([..])
```

implementing would of been pretty difficult since multiple states would need to be maintained. also usage just seems really strange

### option 2 - passing data in `__init__` as `dict`

```python
UnifiedAlchemyMagicMock(data={
    mock.call.filter(): []
})
```

idea is nice but `mock.call`s are not hashable so cannot be used as dict keys. also would need some way to specify multiple methods

### option 3 - passing data in `__init__` as `list` of `([method, method]: [result])` tuples

```python
UnifiedAlchemyMagicMock(data=[
    ([mock.call.filter(), mock.call.order_by()]: []),
])
```

that seems to solve many problems. since `UnifiedAlchemyMagicMock` already unifies various mathods, their order does not matter (although within each method the order of args does matter except `filter` and `filter_by`). also this allows gracefully ignore some methods such as `order_by` simply by not specifying it in the list of clause methods...