### PR TITLE
Use chain.from_iterable in mocking.py

### DIFF
--- a/alchemy_mock/mocking.py
+++ b/alchemy_mock/mocking.py
@@ -434,13 +434,8 @@ class UnifiedAlchemyMagicMock(AlchemyMagicMock):
             if _mock_name == "get":
                 query_call = [c for c in previous_calls if c[0] == "query"][0]
                 results = list(
-                    chain(
-                        *[
-                            result
-                            for calls, result in sorted_mock_data
-                            if query_call in calls
-                        ]
-                    )
+                    chain.from_iterable(result for calls, result in sorted_mock_data
+                                        if query_call in calls)
                 )
                 return self.boundary[_mock_name](results, *args, **kwargs)
 

--- a/alchemy_mock/mocking.py
+++ b/alchemy_mock/mocking.py
@@ -434,8 +434,11 @@ class UnifiedAlchemyMagicMock(AlchemyMagicMock):
             if _mock_name == "get":
                 query_call = [c for c in previous_calls if c[0] == "query"][0]
                 results = list(
-                    chain.from_iterable(result for calls, result in sorted_mock_data
-                                        if query_call in calls)
+                    chain.from_iterable(
+                        result
+                        for calls, result in sorted_mock_data
+                        if query_call in calls
+                    )
                 )
                 return self.boundary[_mock_name](results, *args, **kwargs)
 


### PR DESCRIPTION
This is a faster and more idiomatic way of using `itertools.chain`. Instead of computing all the items in the iterable and storing them in memory, they are computed one-by-one and never stored as a huge list. This can save on both runtime and memory space.